### PR TITLE
Add multi-page Nexus AI-inspired web experience

### DIFF
--- a/web/assets/style.css
+++ b/web/assets/style.css
@@ -1,0 +1,578 @@
+:root {
+  --primary-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  --secondary-gradient: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  --surface: rgba(255, 255, 255, 0.78);
+  --surface-strong: rgba(255, 255, 255, 0.92);
+  --border: rgba(102, 126, 234, 0.22);
+  --shadow: 0 20px 45px -25px rgba(79, 70, 229, 0.45);
+  --shadow-soft: 0 18px 35px -24px rgba(148, 163, 184, 0.55);
+  --text-primary: #111827;
+  --text-secondary: #4b5563;
+  --text-tertiary: #6b7280;
+  --card-gap: clamp(1.25rem, 1.8vw, 1.75rem);
+  --radius-lg: 26px;
+  --radius-md: 20px;
+  --radius-sm: 14px;
+  --max-content-width: 1080px;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  color: var(--text-primary);
+  background: linear-gradient(160deg, #eef2ff 0%, #f5f3ff 35%, #fdf2f8 100%);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
+  backdrop-filter: blur(18px);
+}
+
+.sidebar {
+  width: clamp(16rem, 18vw, 19.5rem);
+  padding: clamp(1.75rem, 2.6vw, 2.75rem) clamp(1.2rem, 2vw, 2.4rem);
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+  position: sticky;
+  top: 0;
+  min-height: 100vh;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-icon {
+  width: clamp(3rem, 3.4vw, 3.4rem);
+  height: clamp(3rem, 3.4vw, 3.4rem);
+  border-radius: 18px;
+  background: var(--primary-gradient);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.35rem;
+  box-shadow: var(--shadow);
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.brand-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.brand-subtitle {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.sidebar-note {
+  padding: 1.25rem 1.3rem;
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  border: 1px solid rgba(79, 70, 229, 0.18);
+  box-shadow: 0 16px 40px -32px rgba(79, 70, 229, 0.45);
+}
+
+.sidebar-note-title {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: #6366f1;
+}
+
+.sidebar-note-subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.85rem 0.95rem;
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-weight: 500;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: #9ca3af;
+  transition: color 0.2s ease;
+}
+
+.nav-link:hover {
+  background: rgba(99, 102, 241, 0.12);
+  color: #4338ca;
+  transform: translateX(4px);
+}
+
+.nav-link:hover svg {
+  color: #6366f1;
+}
+
+.nav-link.active {
+  background: rgba(99, 102, 241, 0.16);
+  color: #4338ca;
+  box-shadow: 0 16px 32px -28px rgba(79, 70, 229, 0.6);
+}
+
+.nav-link.active svg {
+  color: #4f46e5;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding: 1.4rem 1.3rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.06);
+  border: 1px dashed rgba(99, 102, 241, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.sidebar-footer strong {
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.sidebar-footer a {
+  text-decoration: none;
+  color: #4f46e5;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top right, rgba(79, 70, 229, 0.08), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(236, 72, 153, 0.08), transparent 60%);
+}
+
+.topbar {
+  padding: clamp(1.5rem, 2.5vw, 2.3rem) clamp(2rem, 4vw, 3.2rem) clamp(0.75rem, 1.4vw, 1.1rem);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.page-kicker {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: #6366f1;
+  margin-bottom: 0.35rem;
+}
+
+.page-title {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.35rem);
+  font-weight: 700;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.7rem 1.4rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button-primary {
+  background: var(--primary-gradient);
+  color: #fff;
+  box-shadow: var(--shadow);
+}
+
+.button-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 25px 40px -20px rgba(79, 70, 229, 0.55);
+}
+
+.button-ghost {
+  background: rgba(99, 102, 241, 0.14);
+  color: #4338ca;
+}
+
+.button-ghost:hover {
+  transform: translateY(-2px);
+}
+
+.main-content {
+  padding: 0 clamp(2rem, 4vw, 3.2rem) clamp(2.5rem, 4vw, 3.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 3vw, 3rem);
+}
+
+.hero {
+  background: var(--surface-strong);
+  border-radius: var(--radius-lg);
+  padding: clamp(2rem, 3.5vw, 3rem);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: -40% 45% auto -20%;
+  height: 160%;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.2), transparent 70%);
+  z-index: 0;
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #6366f1;
+  background: rgba(99, 102, 241, 0.12);
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.gradient-text {
+  background: var(--primary-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  font-size: clamp(2.35rem, 4vw, 3.25rem);
+  font-weight: 800;
+  margin: 0;
+}
+
+.hero-description {
+  margin: 0;
+  font-size: clamp(1.05rem, 1.6vw, 1.2rem);
+  color: var(--text-secondary);
+  max-width: 46ch;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--card-gap);
+}
+
+.glass-card {
+  background: var(--surface-strong);
+  border-radius: var(--radius-md);
+  padding: clamp(1.35rem, 2vw, 1.8rem);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.glass-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.glass-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.link-inline {
+  color: #4f46e5;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.link-inline:hover {
+  text-decoration: underline;
+}
+
+.split-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--card-gap);
+}
+
+.list {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.list-item {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.list-item strong {
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.list-item span {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(236, 72, 153, 0.12);
+  color: #db2777;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.table-card table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.table-card th,
+.table-card td {
+  padding: 0.8rem 0.6rem;
+  text-align: left;
+}
+
+.table-card th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: #818cf8;
+}
+
+.table-card tr + tr {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.status-pill.positive {
+  background: rgba(16, 185, 129, 0.16);
+  color: #059669;
+}
+
+.status-pill.negative {
+  background: rgba(239, 68, 68, 0.16);
+  color: #dc2626;
+}
+
+.status-pill.neutral {
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+}
+
+.chat-window {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.chat-bubble {
+  border-radius: 20px;
+  padding: 0.85rem 1.1rem;
+  max-width: 36ch;
+  line-height: 1.55;
+}
+
+.chat-bubble.user {
+  margin-left: auto;
+  background: rgba(236, 72, 153, 0.14);
+  color: #be185d;
+}
+
+.chat-bubble.assistant {
+  background: rgba(99, 102, 241, 0.14);
+  color: #312e81;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--card-gap);
+}
+
+.metric {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.metric span {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric strong {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.inline-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.inline-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.1);
+  color: #4338ca;
+  font-size: 0.85rem;
+  text-decoration: none;
+}
+
+.inline-links a svg {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+@media (max-width: 1080px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    position: static;
+    width: 100%;
+    min-height: auto;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .sidebar-note,
+  .sidebar-footer {
+    width: 100%;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    width: 100%;
+  }
+
+  .nav-link {
+    flex: 1 1 180px;
+  }
+}
+
+@media (max-width: 720px) {
+  .topbar {
+    padding: 1.4rem 1.5rem 0.9rem;
+  }
+
+  .main-content {
+    padding: 0 1.5rem 2rem;
+  }
+
+  .hero {
+    padding: 1.85rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sidebar {
+    padding: 1.35rem;
+  }
+}

--- a/web/budget.html
+++ b/web/budget.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nexus AI · Budget Manager</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/style.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-icon">N</div>
+          <div class="brand-text">
+            <span class="brand-title">Nexus AI</span>
+            <span class="brand-subtitle">Command Center</span>
+          </div>
+        </div>
+        <div class="sidebar-note">
+          <p class="sidebar-note-title">Powered by AI</p>
+          <p class="sidebar-note-subtitle">Multi-Modal Intelligence</p>
+        </div>
+        <nav class="sidebar-nav">
+          <a class="nav-link" href="index.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063L2.365 12.48a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063A2 2 0 0 0 14.063 15.5l-1.582 6.135a.5.5 0 0 1-.963 0Z" />
+              <path d="M20 3v4" />
+              <path d="M22 5h-4" />
+              <path d="M4 17v2" />
+              <path d="M5 18H3" />
+            </svg>
+            <span>AI Assistant</span>
+          </a>
+          <a class="nav-link" href="tasks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 4h18" />
+              <path d="M3 12h18" />
+              <path d="M3 20h18" />
+              <path d="M7 8l2 2 4-4" />
+              <path d="M7 16l2 2 4-4" />
+            </svg>
+            <span>Tasks &amp; Reminders</span>
+          </a>
+          <a class="nav-link" href="stocks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <polyline points="18 20 18 10 12 14 6 8 6 20" />
+              <path d="M2 20h20" />
+            </svg>
+            <span>Stock Tracker</span>
+          </a>
+          <a class="nav-link active" href="budget.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 5h15a2 2 0 0 1 2 2v4h-3a2 2 0 0 0 0 4h3v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+              <path d="M17 9h4" />
+            </svg>
+            <span>Budget Manager</span>
+          </a>
+          <a class="nav-link" href="content.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M21 15V9a2 2 0 0 0-2-2h-1l-2-3H8L6 7H5a2 2 0 0 0-2 2v6" />
+              <path d="M3 13h18" />
+              <path d="M10 21h4" />
+              <path d="M9 17h6" />
+            </svg>
+            <span>Content Studio</span>
+          </a>
+          <a class="nav-link" href="settings.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            <span>Settings</span>
+          </a>
+        </nav>
+        <div class="sidebar-footer">
+          <strong>Need automation?</strong>
+          <span>Design flows that connect tasks, finance, and creation in a single workspace.</span>
+          <a href="settings.html">Open automation studio →</a>
+        </div>
+      </aside>
+      <main class="main">
+        <header class="topbar">
+          <div>
+            <p class="page-kicker">Finance</p>
+            <h1 class="page-title">Budget Manager</h1>
+          </div>
+          <div class="topbar-actions">
+            <a class="button button-ghost" href="stocks.html">Sync with markets</a>
+            <a class="button button-primary" href="index.html">Request summary</a>
+          </div>
+        </header>
+        <div class="main-content">
+          <section class="hero">
+            <span class="hero-tag">Cash clarity</span>
+            <h2 class="gradient-text">Understand spend in one glance</h2>
+            <p class="hero-description">Track burn, forecast runway, and automatically surface spend anomalies. Nexus links every line item to owners and next actions.</p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="budget.html">Add expense stream</a>
+              <a class="button button-ghost" href="tasks.html">Create review task</a>
+            </div>
+            <div class="inline-links">
+              <a href="stocks.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <polyline points="6 18 9 15 13 19 18 13" />
+                </svg>
+                Compare to market shifts
+              </a>
+              <a href="content.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M4 4h16v6H4z" />
+                  <path d="M4 14h16v6H4z" />
+                </svg>
+                Generate CFO brief
+              </a>
+              <a href="settings.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M12 20v-8" />
+                  <path d="m8 12 4-4 4 4" />
+                </svg>
+                Adjust guardrails
+              </a>
+            </div>
+          </section>
+
+          <section class="split-layout">
+            <div class="glass-card table-card">
+              <div class="badge">Monthly snapshot</div>
+              <h3>Spending vs plan</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Category</th>
+                    <th>Planned</th>
+                    <th>Actual</th>
+                    <th>Variance</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Product &amp; R&amp;D</td>
+                    <td>$420K</td>
+                    <td>$398K</td>
+                    <td><span class="status-pill positive">-5%</span></td>
+                  </tr>
+                  <tr>
+                    <td>Growth</td>
+                    <td>$210K</td>
+                    <td>$246K</td>
+                    <td><span class="status-pill negative">+17%</span></td>
+                  </tr>
+                  <tr>
+                    <td>Operations</td>
+                    <td>$135K</td>
+                    <td>$128K</td>
+                    <td><span class="status-pill positive">-6%</span></td>
+                  </tr>
+                  <tr>
+                    <td>People</td>
+                    <td>$320K</td>
+                    <td>$315K</td>
+                    <td><span class="status-pill neutral">-2%</span></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="glass-card">
+              <div class="badge">AI insights</div>
+              <h3>Where Nexus sees opportunity</h3>
+              <div class="list">
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="m5 12 5 5 9-11" />
+                  </svg>
+                  <span><strong>Reallocate growth overspend</strong><br />Move $22K from underused ad sets into the automation pilot tracked in <a class="link-inline" href="tasks.html">Tasks</a>.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M3 3h18v18H3z" />
+                    <path d="M9 9h6v6H9z" />
+                  </svg>
+                  <span><strong>Expense anomaly detected</strong><br />Ops SaaS stack spiked 11%. Nexus drafted a vendor consolidation plan in the Content Studio.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M4 4h16v6H4z" />
+                    <path d="M4 14h16v6H4z" />
+                  </svg>
+                  <span><strong>Runway extension</strong><br />Current burn = $1.12M. With adjustments, extend runway to 18.5 months—synced to <a class="link-inline" href="stocks.html">market view</a>.</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="card-grid">
+            <div class="glass-card">
+              <h3>Scenario modeling</h3>
+              <p>Spin up best, base, and stress projections. Nexus auto-creates tasks and investor messaging for each path.</p>
+              <a class="link-inline" href="content.html">Export investor slides →</a>
+            </div>
+            <div class="glass-card">
+              <h3>Compliance ready</h3>
+              <p>Audit logs show who approved spend, when it was executed, and the AI rationale behind every adjustment.</p>
+              <a class="link-inline" href="settings.html">Open governance settings →</a>
+            </div>
+            <div class="glass-card">
+              <h3>Integrations</h3>
+              <p>Connect banks, ERP, HRIS, and analytics. Nexus normalizes data and feeds real-time insights to the assistant.</p>
+              <a class="link-inline" href="index.html">Review data sources →</a>
+            </div>
+          </section>
+
+          <section class="metric-grid">
+            <div class="glass-card metric">
+              <span>Monthly burn</span>
+              <strong>$1.12M</strong>
+              <p>Down 4.2% MoM after automation rollouts.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Runway</span>
+              <strong>16.8 months</strong>
+              <p>Goal: 18+ months after budget refinements.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Approvals pending</span>
+              <strong>6</strong>
+              <p>Awaiting sign-off from Ops, Finance, and Product.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Next checkpoints</span>
+              <p>Board finance review • Vendor refresh • Hiring plan sync</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/web/content.html
+++ b/web/content.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nexus AI · Content Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/style.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-icon">N</div>
+          <div class="brand-text">
+            <span class="brand-title">Nexus AI</span>
+            <span class="brand-subtitle">Command Center</span>
+          </div>
+        </div>
+        <div class="sidebar-note">
+          <p class="sidebar-note-title">Powered by AI</p>
+          <p class="sidebar-note-subtitle">Multi-Modal Intelligence</p>
+        </div>
+        <nav class="sidebar-nav">
+          <a class="nav-link" href="index.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063L2.365 12.48a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063A2 2 0 0 0 14.063 15.5l-1.582 6.135a.5.5 0 0 1-.963 0Z" />
+              <path d="M20 3v4" />
+              <path d="M22 5h-4" />
+              <path d="M4 17v2" />
+              <path d="M5 18H3" />
+            </svg>
+            <span>AI Assistant</span>
+          </a>
+          <a class="nav-link" href="tasks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 4h18" />
+              <path d="M3 12h18" />
+              <path d="M3 20h18" />
+              <path d="M7 8l2 2 4-4" />
+              <path d="M7 16l2 2 4-4" />
+            </svg>
+            <span>Tasks &amp; Reminders</span>
+          </a>
+          <a class="nav-link" href="stocks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <polyline points="18 20 18 10 12 14 6 8 6 20" />
+              <path d="M2 20h20" />
+            </svg>
+            <span>Stock Tracker</span>
+          </a>
+          <a class="nav-link" href="budget.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 5h15a2 2 0 0 1 2 2v4h-3a2 2 0 0 0 0 4h3v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+              <path d="M17 9h4" />
+            </svg>
+            <span>Budget Manager</span>
+          </a>
+          <a class="nav-link active" href="content.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M21 15V9a2 2 0 0 0-2-2h-1l-2-3H8L6 7H5a2 2 0 0 0-2 2v6" />
+              <path d="M3 13h18" />
+              <path d="M10 21h4" />
+              <path d="M9 17h6" />
+            </svg>
+            <span>Content Studio</span>
+          </a>
+          <a class="nav-link" href="settings.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            <span>Settings</span>
+          </a>
+        </nav>
+        <div class="sidebar-footer">
+          <strong>Need automation?</strong>
+          <span>Design flows that connect tasks, finance, and creation in a single workspace.</span>
+          <a href="settings.html">Open automation studio →</a>
+        </div>
+      </aside>
+      <main class="main">
+        <header class="topbar">
+          <div>
+            <p class="page-kicker">Storytelling</p>
+            <h1 class="page-title">Content Studio</h1>
+          </div>
+          <div class="topbar-actions">
+            <a class="button button-ghost" href="index.html">Ask for concept</a>
+            <a class="button button-primary" href="content.html">New project</a>
+          </div>
+        </header>
+        <div class="main-content">
+          <section class="hero">
+            <span class="hero-tag">Create once, publish everywhere</span>
+            <h2 class="gradient-text">Transform ideas into ready-to-ship content</h2>
+            <p class="hero-description">From investor updates to social drops, Nexus AI drafts, edits, and versions every asset with approvals and metrics built in.</p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="content.html">Start with a template</a>
+              <a class="button button-ghost" href="tasks.html">Assign reviewers</a>
+            </div>
+            <div class="inline-links">
+              <a href="index.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M12 20v-8" />
+                  <path d="m8 12 4-4 4 4" />
+                </svg>
+                Generate script ideas
+              </a>
+              <a href="budget.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M4 4h16v6H4z" />
+                  <path d="M4 14h16v6H4z" />
+                </svg>
+                Attach budget insights
+              </a>
+              <a href="stocks.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <polyline points="6 18 9 15 13 19 18 13" />
+                </svg>
+                Pull market data
+              </a>
+            </div>
+          </section>
+
+          <section class="card-grid">
+            <div class="glass-card">
+              <div class="badge">Video</div>
+              <h3>Launch video storyboard</h3>
+              <p>Nexus drafts shot lists, voiceover scripts, and overlays. Export to your editor or send to production straight from the Studio.</p>
+              <a class="link-inline" href="index.html">Preview the storyboard →</a>
+            </div>
+            <div class="glass-card">
+              <div class="badge">Newsletter</div>
+              <h3>Investor update</h3>
+              <p>Blend financial metrics from Budget Manager with market context. Collaborators can leave inline feedback before it ships.</p>
+              <a class="link-inline" href="budget.html">Insert financial highlights →</a>
+            </div>
+            <div class="glass-card">
+              <div class="badge">Social</div>
+              <h3>Multi-platform campaign</h3>
+              <p>Auto-generate posts for LinkedIn, X, Threads, and community channels. Schedule tasks and measure performance in one place.</p>
+              <a class="link-inline" href="tasks.html">Queue publication tasks →</a>
+            </div>
+          </section>
+
+          <section class="split-layout">
+            <div class="glass-card">
+              <div class="badge">Workflow</div>
+              <h3>Collaborate with confidence</h3>
+              <div class="list">
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="m5 12 5 5 9-11" />
+                  </svg>
+                  <span><strong>Role-aware approvals</strong><br />Assign approvers, set deadlines, and auto-create follow-up tasks if feedback is overdue.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M3 3h18v18H3z" />
+                    <path d="M9 9h6v6H9z" />
+                  </svg>
+                  <span><strong>Version history</strong><br />Every prompt, revision, and publish event stays in sync across campaigns.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M4 4h16v6H4z" />
+                    <path d="M4 14h16v6H4z" />
+                  </svg>
+                  <span><strong>Performance feedback</strong><br />Connect analytics so the assistant can suggest next best creative moves.</span>
+                </div>
+              </div>
+            </div>
+            <div class="glass-card">
+              <div class="badge">Asset locker</div>
+              <h3>One library, many outputs</h3>
+              <p>Upload brand guidelines, tone cues, creative briefs, and raw assets. Nexus references everything whenever you spin up something new.</p>
+              <a class="link-inline" href="settings.html">Manage brand kit →</a>
+            </div>
+          </section>
+
+          <section class="metric-grid">
+            <div class="glass-card metric">
+              <span>Projects in flight</span>
+              <strong>9</strong>
+              <p>Product launch, quarterly investor note, growth drip, hiring campaign, more.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Average turnaround</span>
+              <strong>2.3 days</strong>
+              <p>AI drafts + approvals reduce production by 48%.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Channels covered</span>
+              <p>Video • Email • Blog • Social • Community • Internal</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Next deliverable</span>
+              <p>Final investor deck → pulling data from <a class="link-inline" href="budget.html">Budget Manager</a>.</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nexus AI · Command Center</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/style.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-icon">N</div>
+          <div class="brand-text">
+            <span class="brand-title">Nexus AI</span>
+            <span class="brand-subtitle">Command Center</span>
+          </div>
+        </div>
+        <div class="sidebar-note">
+          <p class="sidebar-note-title">Powered by AI</p>
+          <p class="sidebar-note-subtitle">Multi-Modal Intelligence</p>
+        </div>
+        <nav class="sidebar-nav">
+          <a class="nav-link active" href="index.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063L2.365 12.48a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063A2 2 0 0 0 14.063 15.5l-1.582 6.135a.5.5 0 0 1-.963 0Z" />
+              <path d="M20 3v4" />
+              <path d="M22 5h-4" />
+              <path d="M4 17v2" />
+              <path d="M5 18H3" />
+            </svg>
+            <span>AI Assistant</span>
+          </a>
+          <a class="nav-link" href="tasks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 4h18" />
+              <path d="M3 12h18" />
+              <path d="M3 20h18" />
+              <path d="M7 8l2 2 4-4" />
+              <path d="M7 16l2 2 4-4" />
+            </svg>
+            <span>Tasks &amp; Reminders</span>
+          </a>
+          <a class="nav-link" href="stocks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <polyline points="18 20 18 10 12 14 6 8 6 20" />
+              <path d="M2 20h20" />
+            </svg>
+            <span>Stock Tracker</span>
+          </a>
+          <a class="nav-link" href="budget.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 5h15a2 2 0 0 1 2 2v4h-3a2 2 0 0 0 0 4h3v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+              <path d="M17 9h4" />
+            </svg>
+            <span>Budget Manager</span>
+          </a>
+          <a class="nav-link" href="content.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M21 15V9a2 2 0 0 0-2-2h-1l-2-3H8L6 7H5a2 2 0 0 0-2 2v6" />
+              <path d="M3 13h18" />
+              <path d="M10 21h4" />
+              <path d="M9 17h6" />
+            </svg>
+            <span>Content Studio</span>
+          </a>
+          <a class="nav-link" href="settings.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            <span>Settings</span>
+          </a>
+        </nav>
+        <div class="sidebar-footer">
+          <strong>Need automation?</strong>
+          <span>Design flows that connect tasks, finance, and creation in a single workspace.</span>
+          <a href="settings.html">Open automation studio →</a>
+        </div>
+      </aside>
+      <main class="main">
+        <header class="topbar">
+          <div>
+            <p class="page-kicker">AI Command</p>
+            <h1 class="page-title">AI Assistant</h1>
+          </div>
+          <div class="topbar-actions">
+            <a class="button button-ghost" href="tasks.html">View schedules</a>
+            <a class="button button-primary" href="content.html">Start new request</a>
+          </div>
+        </header>
+        <div class="main-content">
+          <section class="hero">
+            <span class="hero-tag">Your Personal Assistant</span>
+            <h2 class="gradient-text">What can I help you with today?</h2>
+            <p class="hero-description">I can assist with tasks, content creation, research, finance tracking, and more—everything lives inside your Nexus workspace.</p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="content.html">Generate content</a>
+              <a class="button button-ghost" href="tasks.html">Automate my day</a>
+            </div>
+            <div class="inline-links">
+              <a href="tasks.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M5 12h14" />
+                  <path d="m12 5 7 7-7 7" />
+                </svg>
+                Schedule a follow-up
+              </a>
+              <a href="stocks.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <polyline points="6 17 10 11 14 15 18 9" />
+                </svg>
+                Track portfolio health
+              </a>
+              <a href="budget.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M4 12h16" />
+                  <path d="M4 6h16" />
+                  <path d="M4 18h7" />
+                </svg>
+                Balance this month’s spend
+              </a>
+              <a href="content.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M17 3h4v4" />
+                  <path d="M12 8 21 3" />
+                  <path d="M12 12v7" />
+                  <path d="M9 21h6" />
+                </svg>
+                Draft a launch script
+              </a>
+            </div>
+          </section>
+
+          <section class="card-grid">
+            <div class="glass-card">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14Z" />
+              </svg>
+              <h3>Quick Tasks</h3>
+              <p>Set reminders, build checklists, and receive nudges before anything slips. Every action syncs with Tasks &amp; Reminders.</p>
+              <a class="link-inline" href="tasks.html">Review the task queue →</a>
+            </div>
+            <div class="glass-card">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z" />
+                <path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z" />
+                <path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4" />
+              </svg>
+              <h3>Research &amp; Learn</h3>
+              <p>Ask for summaries, explanations, or deep dives. Nexus pulls live knowledge into a briefing you can share instantly.</p>
+              <a class="link-inline" href="content.html">Build a knowledge brief →</a>
+            </div>
+            <div class="glass-card">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path d="M4 17v-2" />
+                <path d="M20 7V3" />
+                <path d="M4 13v-2" />
+                <path d="M4 9V7" />
+                <path d="M12 21V3" />
+                <path d="M20 21v-4" />
+                <path d="M20 13v-2" />
+                <path d="M20 9V7" />
+                <path d="M4 21v-2" />
+              </svg>
+              <h3>Create Content</h3>
+              <p>Generate scripts, outlines, and creative assets. The Content Studio keeps versions, drafts, and approvals aligned.</p>
+              <a class="link-inline" href="content.html">Open the studio →</a>
+            </div>
+          </section>
+
+          <section class="split-layout">
+            <div class="glass-card">
+              <div class="badge">Suggested</div>
+              <h3>High-impact starters</h3>
+              <div class="list">
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="m5 12 5 5 9-11" />
+                  </svg>
+                  <span><strong>Stand-up summary</strong><br />Collect notes from your team, generate highlights, and schedule follow-up tasks.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M12 20a8 8 0 1 0-8-8" />
+                    <path d="M12 6v6l3 3" />
+                  </svg>
+                  <span><strong>Investment pulse</strong><br />Review today's gainers, losers, and AI insights before the closing bell.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M4 4h16v6H4z" />
+                    <path d="M4 14h16v6H4z" />
+                  </svg>
+                  <span><strong>Budget rescue</strong><br />Reconcile incoming invoices, forecast runway, and export a CFO-ready snapshot.</span>
+                </div>
+              </div>
+            </div>
+            <div class="glass-card chat-window">
+              <div class="badge">Live conversation</div>
+              <div class="chat-bubble user">I need a launch plan for the new Nexus automation feature.</div>
+              <div class="chat-bubble assistant">Absolutely. I'll draft the messaging pillars, build a 3-week campaign timeline, and sync the schedule to Tasks.</div>
+              <div class="chat-bubble user">Perfect—include a budget breakdown and investor update.</div>
+              <div class="chat-bubble assistant">Done. Budget insights pulled from Budget Manager and the investor brief is queued in Content Studio.</div>
+            </div>
+          </section>
+
+          <section class="metric-grid">
+            <div class="glass-card metric">
+              <span>Active automations</span>
+              <strong>18</strong>
+              <p>Flows running across tasks, finance, and content.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Hours saved this week</span>
+              <strong>12.4</strong>
+              <p>Estimated time returned by Nexus AI suggestions.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Focus areas</span>
+              <p>Strategy, Finance, Content, Operations</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Next best action</span>
+              <p>Finalize Q4 automation rollout inside <a class="link-inline" href="settings.html">Settings</a>.</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/web/settings.html
+++ b/web/settings.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nexus AI · Settings</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/style.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-icon">N</div>
+          <div class="brand-text">
+            <span class="brand-title">Nexus AI</span>
+            <span class="brand-subtitle">Command Center</span>
+          </div>
+        </div>
+        <div class="sidebar-note">
+          <p class="sidebar-note-title">Powered by AI</p>
+          <p class="sidebar-note-subtitle">Multi-Modal Intelligence</p>
+        </div>
+        <nav class="sidebar-nav">
+          <a class="nav-link" href="index.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063L2.365 12.48a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063A2 2 0 0 0 14.063 15.5l-1.582 6.135a.5.5 0 0 1-.963 0Z" />
+              <path d="M20 3v4" />
+              <path d="M22 5h-4" />
+              <path d="M4 17v2" />
+              <path d="M5 18H3" />
+            </svg>
+            <span>AI Assistant</span>
+          </a>
+          <a class="nav-link" href="tasks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 4h18" />
+              <path d="M3 12h18" />
+              <path d="M3 20h18" />
+              <path d="M7 8l2 2 4-4" />
+              <path d="M7 16l2 2 4-4" />
+            </svg>
+            <span>Tasks &amp; Reminders</span>
+          </a>
+          <a class="nav-link" href="stocks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <polyline points="18 20 18 10 12 14 6 8 6 20" />
+              <path d="M2 20h20" />
+            </svg>
+            <span>Stock Tracker</span>
+          </a>
+          <a class="nav-link" href="budget.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 5h15a2 2 0 0 1 2 2v4h-3a2 2 0 0 0 0 4h3v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+              <path d="M17 9h4" />
+            </svg>
+            <span>Budget Manager</span>
+          </a>
+          <a class="nav-link" href="content.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M21 15V9a2 2 0 0 0-2-2h-1l-2-3H8L6 7H5a2 2 0 0 0-2 2v6" />
+              <path d="M3 13h18" />
+              <path d="M10 21h4" />
+              <path d="M9 17h6" />
+            </svg>
+            <span>Content Studio</span>
+          </a>
+          <a class="nav-link active" href="settings.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            <span>Settings</span>
+          </a>
+        </nav>
+        <div class="sidebar-footer">
+          <strong>Need automation?</strong>
+          <span>Design flows that connect tasks, finance, and creation in a single workspace.</span>
+          <a href="settings.html">Open automation studio →</a>
+        </div>
+      </aside>
+      <main class="main">
+        <header class="topbar">
+          <div>
+            <p class="page-kicker">Control</p>
+            <h1 class="page-title">Workspace Settings</h1>
+          </div>
+          <div class="topbar-actions">
+            <a class="button button-ghost" href="index.html">Preview changes</a>
+            <a class="button button-primary" href="settings.html">Save profile</a>
+          </div>
+        </header>
+        <div class="main-content">
+          <section class="hero">
+            <span class="hero-tag">Configuration</span>
+            <h2 class="gradient-text">Fine-tune every Nexus experience</h2>
+            <p class="hero-description">Set assistant tone, automation cadence, permissions, and security policies. All adjustments apply instantly across tasks, finance, and content.</p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="settings.html">Create new preset</a>
+              <a class="button button-ghost" href="tasks.html">Sync with task rules</a>
+            </div>
+            <div class="inline-links">
+              <a href="budget.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M4 4h16v6H4z" />
+                </svg>
+                Update finance guardrails
+              </a>
+              <a href="content.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M12 20v-8" />
+                  <path d="m8 12 4-4 4 4" />
+                </svg>
+                Refresh brand kit
+              </a>
+              <a href="stocks.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <polyline points="6 18 9 15 13 19 18 13" />
+                </svg>
+                Adjust market alerts
+              </a>
+            </div>
+          </section>
+
+          <section class="split-layout">
+            <div class="glass-card">
+              <div class="badge">Assistant</div>
+              <h3>Voice &amp; tone</h3>
+              <div class="list">
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="m5 12 5 5 9-11" />
+                  </svg>
+                  <span><strong>Personality preset</strong><br />Strategic, concise, or playful. Nexus adapts phrasing in chat, briefs, and announcements.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M3 3h18v18H3z" />
+                    <path d="M9 9h6v6H9z" />
+                  </svg>
+                  <span><strong>Language coverage</strong><br />Enable automatic translation for external content and transcripts.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M4 4h16v6H4z" />
+                    <path d="M4 14h16v6H4z" />
+                  </svg>
+                  <span><strong>Knowledge sources</strong><br />Manage connected docs, wikis, and dashboards that power responses.</span>
+                </div>
+              </div>
+            </div>
+            <div class="glass-card">
+              <div class="badge">Security</div>
+              <h3>Access &amp; compliance</h3>
+              <div class="list">
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M12 12a4 4 0 1 0-4-4" />
+                    <path d="M12 12v8" />
+                    <path d="m8 16 4 4 4-4" />
+                  </svg>
+                  <span><strong>Role-based policies</strong><br />Define who can approve spend, publish content, or place trades.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M3 3h18v18H3z" />
+                    <path d="M9 9h6v6H9z" />
+                  </svg>
+                  <span><strong>Data residency</strong><br />Choose storage regions and retention policies for sensitive artifacts.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M4 4h16v6H4z" />
+                    <path d="M4 14h16v6H4z" />
+                  </svg>
+                  <span><strong>Audit exports</strong><br />Schedule automated compliance packets for finance and legal teams.</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="card-grid">
+            <div class="glass-card">
+              <h3>Automation presets</h3>
+              <p>Bundle recurring workflows into shareable playbooks. Each preset maps to tasks, finance, or content triggers.</p>
+              <a class="link-inline" href="tasks.html">Open automation library →</a>
+            </div>
+            <div class="glass-card">
+              <h3>Notification rules</h3>
+              <p>Set quiet hours, channel preferences, and escalation paths. Nexus learns your focus windows automatically.</p>
+              <a class="link-inline" href="tasks.html">Edit reminder logic →</a>
+            </div>
+            <div class="glass-card">
+              <h3>Integrations</h3>
+              <p>Connect calendars, CRMs, billing platforms, data warehouses, and more. Use the assistant to orchestrate syncs.</p>
+              <a class="link-inline" href="index.html">See connected apps →</a>
+            </div>
+          </section>
+
+          <section class="metric-grid">
+            <div class="glass-card metric">
+              <span>Active members</span>
+              <strong>84</strong>
+              <p>Across product, finance, marketing, operations, and leadership.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Automations</span>
+              <strong>32 presets</strong>
+              <p>Live across tasks, budgets, and content flows.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Security posture</span>
+              <p>SOC2 Type II • SSO enforced • Region: US &amp; EU clusters</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Latest changes</span>
+              <p>Finance guardrails updated • Content tone = Strategic • Alert window 08:00-18:00</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/web/stocks.html
+++ b/web/stocks.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nexus AI · Stock Tracker</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/style.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-icon">N</div>
+          <div class="brand-text">
+            <span class="brand-title">Nexus AI</span>
+            <span class="brand-subtitle">Command Center</span>
+          </div>
+        </div>
+        <div class="sidebar-note">
+          <p class="sidebar-note-title">Powered by AI</p>
+          <p class="sidebar-note-subtitle">Multi-Modal Intelligence</p>
+        </div>
+        <nav class="sidebar-nav">
+          <a class="nav-link" href="index.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063L2.365 12.48a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063A2 2 0 0 0 14.063 15.5l-1.582 6.135a.5.5 0 0 1-.963 0Z" />
+              <path d="M20 3v4" />
+              <path d="M22 5h-4" />
+              <path d="M4 17v2" />
+              <path d="M5 18H3" />
+            </svg>
+            <span>AI Assistant</span>
+          </a>
+          <a class="nav-link" href="tasks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 4h18" />
+              <path d="M3 12h18" />
+              <path d="M3 20h18" />
+              <path d="M7 8l2 2 4-4" />
+              <path d="M7 16l2 2 4-4" />
+            </svg>
+            <span>Tasks &amp; Reminders</span>
+          </a>
+          <a class="nav-link active" href="stocks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <polyline points="18 20 18 10 12 14 6 8 6 20" />
+              <path d="M2 20h20" />
+            </svg>
+            <span>Stock Tracker</span>
+          </a>
+          <a class="nav-link" href="budget.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 5h15a2 2 0 0 1 2 2v4h-3a2 2 0 0 0 0 4h3v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+              <path d="M17 9h4" />
+            </svg>
+            <span>Budget Manager</span>
+          </a>
+          <a class="nav-link" href="content.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M21 15V9a2 2 0 0 0-2-2h-1l-2-3H8L6 7H5a2 2 0 0 0-2 2v6" />
+              <path d="M3 13h18" />
+              <path d="M10 21h4" />
+              <path d="M9 17h6" />
+            </svg>
+            <span>Content Studio</span>
+          </a>
+          <a class="nav-link" href="settings.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            <span>Settings</span>
+          </a>
+        </nav>
+        <div class="sidebar-footer">
+          <strong>Need automation?</strong>
+          <span>Design flows that connect tasks, finance, and creation in a single workspace.</span>
+          <a href="settings.html">Open automation studio →</a>
+        </div>
+      </aside>
+      <main class="main">
+        <header class="topbar">
+          <div>
+            <p class="page-kicker">Markets</p>
+            <h1 class="page-title">Stock Tracker</h1>
+          </div>
+          <div class="topbar-actions">
+            <a class="button button-ghost" href="budget.html">Sync with budgets</a>
+            <a class="button button-primary" href="index.html">Ask for analysis</a>
+          </div>
+        </header>
+        <div class="main-content">
+          <section class="hero">
+            <span class="hero-tag">Live intelligence</span>
+            <h2 class="gradient-text">Stay ahead of every market move</h2>
+            <p class="hero-description">Nexus watches your portfolio, surfaces AI sentiment, and ties movements back to revenue, burn, and task planning.</p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="stocks.html">Add a ticker</a>
+              <a class="button button-ghost" href="content.html">Generate investor brief</a>
+            </div>
+            <div class="inline-links">
+              <a href="tasks.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M4 4h16v6H4z" />
+                </svg>
+                Create follow-up tasks
+              </a>
+              <a href="budget.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M3 12h18" />
+                  <path d="M3 6h18" />
+                </svg>
+                Compare against runway
+              </a>
+              <a href="index.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M3 10h18" />
+                  <path d="M12 4v16" />
+                </svg>
+                Request AI recap
+              </a>
+            </div>
+          </section>
+
+          <section class="split-layout">
+            <div class="glass-card table-card">
+              <div class="badge">Portfolio overview</div>
+              <h3>Core holdings</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Ticker</th>
+                    <th>Allocation</th>
+                    <th>Day change</th>
+                    <th>Signal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>NXS</td>
+                    <td>32%</td>
+                    <td><span class="status-pill positive">+3.4%</span></td>
+                    <td>Momentum</td>
+                  </tr>
+                  <tr>
+                    <td>AIQ</td>
+                    <td>18%</td>
+                    <td><span class="status-pill negative">-1.2%</span></td>
+                    <td>Rebalance</td>
+                  </tr>
+                  <tr>
+                    <td>GTX</td>
+                    <td>14%</td>
+                    <td><span class="status-pill positive">+0.9%</span></td>
+                    <td>Hold</td>
+                  </tr>
+                  <tr>
+                    <td>CRN</td>
+                    <td>12%</td>
+                    <td><span class="status-pill neutral">0.0%</span></td>
+                    <td>Watchlist</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="glass-card">
+              <div class="badge">AI Sentiment</div>
+              <h3>Signals + recommended actions</h3>
+              <div class="list">
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="m5 12 5 5 9-11" />
+                  </svg>
+                  <span><strong>Earnings beat for NXS</strong><br />Allocate surplus into automation R&amp;D. Task the finance squad inside <a class="link-inline" href="budget.html">Budget Manager</a>.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M3 3h18v18H3z" />
+                    <path d="M9 9h6v6H9z" />
+                  </svg>
+                  <span><strong>Volatility spike on AIQ</strong><br />Nexus suggests trimming 4% and spinning up an investor FAQ through the Content Studio.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M4 4h16v6H4z" />
+                    <path d="M4 14h16v6H4z" />
+                  </svg>
+                  <span><strong>Liquidity check</strong><br />Cash runway remains 14.2 months. Link insights back to <a class="link-inline" href="tasks.html">operations review</a>.</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="card-grid">
+            <div class="glass-card">
+              <h3>Watchlists</h3>
+              <p>Create thematic watchlists—AI infrastructure, creator economy, or green tech—and let Nexus alert you to major swings.</p>
+              <a class="link-inline" href="index.html">Stream alerts via assistant →</a>
+            </div>
+            <div class="glass-card">
+              <h3>Scenario planning</h3>
+              <p>Forecast best and worst case outcomes, then sync budgets and tasks around the plan Nexus recommends.</p>
+              <a class="link-inline" href="budget.html">Model the impact →</a>
+            </div>
+            <div class="glass-card">
+              <h3>Compliance ready</h3>
+              <p>All trades, commentary, and AI explanations are logged. Export a shareable digest directly from Content Studio.</p>
+              <a class="link-inline" href="content.html">Draft the digest →</a>
+            </div>
+          </section>
+
+          <section class="metric-grid">
+            <div class="glass-card metric">
+              <span>Total portfolio</span>
+              <strong>$4.6M</strong>
+              <p>Across growth, income, and experimental buckets.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>YTD performance</span>
+              <strong>+18.7%</strong>
+              <p>Outperforming benchmark by 6.2%.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Alerts triggered</span>
+              <strong>5</strong>
+              <p>2 price, 1 macro, 2 risk. Routed to <a class="link-inline" href="tasks.html">task board</a>.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Next brief</span>
+              <p>Investor update scheduled for Friday · Pre-read drafting in <a class="link-inline" href="content.html">Content Studio</a>.</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nexus AI · Tasks &amp; Reminders</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/style.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-icon">N</div>
+          <div class="brand-text">
+            <span class="brand-title">Nexus AI</span>
+            <span class="brand-subtitle">Command Center</span>
+          </div>
+        </div>
+        <div class="sidebar-note">
+          <p class="sidebar-note-title">Powered by AI</p>
+          <p class="sidebar-note-subtitle">Multi-Modal Intelligence</p>
+        </div>
+        <nav class="sidebar-nav">
+          <a class="nav-link" href="index.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063L2.365 12.48a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063A2 2 0 0 0 14.063 15.5l-1.582 6.135a.5.5 0 0 1-.963 0Z" />
+              <path d="M20 3v4" />
+              <path d="M22 5h-4" />
+              <path d="M4 17v2" />
+              <path d="M5 18H3" />
+            </svg>
+            <span>AI Assistant</span>
+          </a>
+          <a class="nav-link active" href="tasks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 4h18" />
+              <path d="M3 12h18" />
+              <path d="M3 20h18" />
+              <path d="M7 8l2 2 4-4" />
+              <path d="M7 16l2 2 4-4" />
+            </svg>
+            <span>Tasks &amp; Reminders</span>
+          </a>
+          <a class="nav-link" href="stocks.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <polyline points="18 20 18 10 12 14 6 8 6 20" />
+              <path d="M2 20h20" />
+            </svg>
+            <span>Stock Tracker</span>
+          </a>
+          <a class="nav-link" href="budget.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 5h15a2 2 0 0 1 2 2v4h-3a2 2 0 0 0 0 4h3v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+              <path d="M17 9h4" />
+            </svg>
+            <span>Budget Manager</span>
+          </a>
+          <a class="nav-link" href="content.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M21 15V9a2 2 0 0 0-2-2h-1l-2-3H8L6 7H5a2 2 0 0 0-2 2v6" />
+              <path d="M3 13h18" />
+              <path d="M10 21h4" />
+              <path d="M9 17h6" />
+            </svg>
+            <span>Content Studio</span>
+          </a>
+          <a class="nav-link" href="settings.html">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            <span>Settings</span>
+          </a>
+        </nav>
+        <div class="sidebar-footer">
+          <strong>Need automation?</strong>
+          <span>Design flows that connect tasks, finance, and creation in a single workspace.</span>
+          <a href="settings.html">Open automation studio →</a>
+        </div>
+      </aside>
+      <main class="main">
+        <header class="topbar">
+          <div>
+            <p class="page-kicker">Productivity</p>
+            <h1 class="page-title">Tasks &amp; Reminders</h1>
+          </div>
+          <div class="topbar-actions">
+            <a class="button button-ghost" href="index.html">Ask the assistant</a>
+            <a class="button button-primary" href="content.html">Create recap</a>
+          </div>
+        </header>
+        <div class="main-content">
+          <section class="hero">
+            <span class="hero-tag">Today's focus</span>
+            <h2 class="gradient-text">Orchestrate every deliverable</h2>
+            <p class="hero-description">Centralize meetings, deadlines, and nudges. Nexus routes the right prompt to the right teammate and keeps priorities synchronized.</p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="tasks.html">New smart task</a>
+              <a class="button button-ghost" href="stocks.html">Review financial blockers</a>
+            </div>
+            <div class="inline-links">
+              <a href="index.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M3 12h18" />
+                  <path d="M12 5v14" />
+                </svg>
+                Talk through priorities
+              </a>
+              <a href="content.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path d="M12 20v-8" />
+                  <path d="m8 12 4-4 4 4" />
+                </svg>
+                Turn notes into docs
+              </a>
+              <a href="settings.html">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M12 6v6l3 3" />
+                </svg>
+                Adjust automation cadence
+              </a>
+            </div>
+          </section>
+
+          <section class="split-layout">
+            <div class="glass-card table-card">
+              <div class="badge">Upcoming schedule</div>
+              <h3>Next on deck</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Time</th>
+                    <th>Task</th>
+                    <th>Owner</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>08:30</td>
+                    <td>Daily stand-up sync</td>
+                    <td>Product squad</td>
+                    <td><span class="status-pill positive">Ready</span></td>
+                  </tr>
+                  <tr>
+                    <td>11:00</td>
+                    <td>Budget review dry-run</td>
+                    <td>Finance lead</td>
+                    <td><span class="status-pill neutral">In prep</span></td>
+                  </tr>
+                  <tr>
+                    <td>14:30</td>
+                    <td>Investor update draft</td>
+                    <td>Content studio</td>
+                    <td><span class="status-pill negative">Needs input</span></td>
+                  </tr>
+                  <tr>
+                    <td>16:00</td>
+                    <td>Automation QA sweep</td>
+                    <td>Ops</td>
+                    <td><span class="status-pill positive">On track</span></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="glass-card">
+              <div class="badge">Automation recipes</div>
+              <h3>Let Nexus drive the follow-through</h3>
+              <div class="list">
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="m5 12 5 5 9-11" />
+                  </svg>
+                  <span><strong>Meeting digest → tasks</strong><br />Convert meeting transcripts into assignments, deadlines, and owners in one pass.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M3 3h18v18H3z" />
+                    <path d="m9 9 6 6" />
+                    <path d="m15 9-6 6" />
+                  </svg>
+                  <span><strong>Escalate blockers</strong><br />If a task slips twice, notify the owner, draft a recap, and flag Finance if budgets are touched.</span>
+                </div>
+                <div class="list-item">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path d="M12 6v6l3 3" />
+                    <path d="M4.9 4.9 3 3" />
+                    <path d="m20.1 4.9 1.9-1.9" />
+                    <path d="M4 21h16" />
+                  </svg>
+                  <span><strong>Weekend reset</strong><br />Clear residual tasks, prepare a Monday briefing, and schedule deep work blocks.</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="card-grid">
+            <div class="glass-card">
+              <h3>Shared boards</h3>
+              <p>Switch between team rituals, personal boards, and exec dashboards with a tap. Everything inherits assistant context.</p>
+              <a class="link-inline" href="index.html">Open in AI Assistant →</a>
+            </div>
+            <div class="glass-card">
+              <h3>Reminder intelligence</h3>
+              <p>Adaptive notifications prioritize high-impact work and pause pings when you’re presenting or heads-down.</p>
+              <a class="link-inline" href="settings.html">Tune notification windows →</a>
+            </div>
+            <div class="glass-card">
+              <h3>Connect workstreams</h3>
+              <p>Link tasks to budgets, stock triggers, and content approvals for complete visibility across Nexus.</p>
+              <a class="link-inline" href="budget.html">Map financial tasks →</a>
+            </div>
+          </section>
+
+          <section class="metric-grid">
+            <div class="glass-card metric">
+              <span>Open tasks</span>
+              <strong>42</strong>
+              <p>Auto-prioritized by urgency, impact, and owner capacity.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Automation coverage</span>
+              <strong>76%</strong>
+              <p>Workflows that progress without manual follow-up.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Overdue items</span>
+              <strong>3</strong>
+              <p>Escalations queued in <a class="link-inline" href="index.html">assistant chat</a>.</p>
+            </div>
+            <div class="glass-card metric">
+              <span>Upcoming reviews</span>
+              <p>Finance retro • Investor memo • Sprint 28 planning</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a static `web/` workspace that mirrors the Nexus AI shell with navigation, hero content, feature cards, and cross-links between tools
- implement Tailwind-inspired gradients, glassmorphism, and responsive layout rules in a shared stylesheet for the assistant and vertical pages
- create dedicated pages for Tasks, Stocks, Budget, Content Studio, and Settings with contextual copy, tables, metrics, and links back to related sections

## Testing
- python -m http.server 8000 (manual visual check)

------
https://chatgpt.com/codex/tasks/task_e_68df1264a604833380cae2448b578f71